### PR TITLE
feat: add bitcoin payment capability

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -239,7 +239,13 @@ Represents a JSON Web Signature (JWS) used to verify the integrity of the AgentC
   "capabilities": {
     "streaming": true,
     "pushNotifications": true,
-    "stateTransitionHistory": false
+    "stateTransitionHistory": false,
+    "payment": {
+      "bitcoin": {
+        "payTo": "bc1qexampleaddress12345",
+        "network": "mainnet"
+      }
+    }
   },
   "securitySchemes": {
     "google": {

--- a/docs/topics/bitcoin-payments.md
+++ b/docs/topics/bitcoin-payments.md
@@ -1,0 +1,43 @@
+# Bitcoin Payments and Wallet Delegation
+
+This extension demonstrates how agents can advertise the ability to accept Bitcoin payments or delegate spend rights via PSBTs.
+
+## Declaring Support
+
+Agents expose the `payment` capability within their Agent Card. A minimal example:
+
+```json
+{
+  "capabilities": {
+    "payment": {
+      "bitcoin": {
+        "payTo": "bc1qexampleaddress12345",
+        "network": "mainnet"
+      }
+    }
+  }
+}
+```
+
+## Delegation
+
+For delegated spending, include a `delegation` object describing the maximum amount, expiry time, and PSBT template:
+
+```json
+{
+  "capabilities": {
+    "payment": {
+      "bitcoin": {
+        "payTo": "bc1qexampleaddress12345",
+        "delegation": {
+          "maxSatoshis": 10000,
+          "expiry": "2030-01-01T00:00:00Z",
+          "psbt": "cHNidP8BAHECAAAAAVDP..."
+        }
+      }
+    }
+  }
+}
+```
+
+The receiving agent validates and partially signs the PSBT, returning the signed transaction to the requester.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
     - Enterprise-Ready Features: topics/enterprise-ready.md
     - Streaming & Asynchronous Operations: topics/streaming-and-async.md
     - Extensions: topics/extensions.md
+    - Bitcoin Payments: topics/bitcoin-payments.md
     - Life of a Task: topics/life-of-a-task.md
   - Specification: specification.md
   - Community: community.md

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -114,6 +114,10 @@
                     },
                     "type": "array"
                 },
+                "payment": {
+                    "$ref": "#/definitions/PaymentCapability",
+                    "description": "Configuration for making or delegating payments via supported rails."
+                },
                 "pushNotifications": {
                     "description": "Indicates if the agent supports sending push notifications for asynchronous task updates.",
                     "type": "boolean"
@@ -504,6 +508,51 @@
                 "authorizationUrl",
                 "scopes",
                 "tokenUrl"
+            ],
+            "type": "object"
+        },
+        "BitcoinCapability": {
+            "description": "Parameters for Bitcoin payments or PSBT-based delegation.",
+            "properties": {
+                "delegation": {
+                    "description": "Optional PSBT delegation information.",
+                    "properties": {
+                        "expiry": {
+                            "description": "Expiration timestamp for the delegation, ISO 8601.",
+                            "type": "string"
+                        },
+                        "maxSatoshis": {
+                            "description": "Maximum amount authorized in satoshis.",
+                            "type": "integer"
+                        },
+                        "psbt": {
+                            "description": "Base64 encoded PSBT template to sign.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "expiry",
+                        "maxSatoshis",
+                        "psbt"
+                    ],
+                    "type": "object"
+                },
+                "network": {
+                    "description": "Network the address resides on. Defaults to mainnet.",
+                    "enum": [
+                        "mainnet",
+                        "signet",
+                        "testnet"
+                    ],
+                    "type": "string"
+                },
+                "payTo": {
+                    "description": "Receiving address for direct payments.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "payTo"
             ],
             "type": "object"
         },
@@ -1715,6 +1764,16 @@
                 "scopes",
                 "tokenUrl"
             ],
+            "type": "object"
+        },
+        "PaymentCapability": {
+            "description": "Configuration for payment handling supported by the agent.",
+            "properties": {
+                "bitcoin": {
+                    "$ref": "#/definitions/BitcoinCapability",
+                    "description": "Bitcoin-specific payment parameters."
+                }
+            },
             "type": "object"
         },
         "PushNotificationAuthenticationInfo": {

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -71,14 +71,17 @@ export interface BitcoinCapability {
   /** Receiving address for direct payments. */
   payTo: string;
   /** Optional PSBT delegation information. */
-  delegation?: {
-    /** Maximum amount authorized in satoshis. */
-    maxSatoshis: number;
-    /** Expiration timestamp for the delegation, ISO 8601. */
-    expiry: string;
-    /** Base64 encoded PSBT template to sign. */
-    psbt: string;
-  };
+  delegation?: BitcoinDelegation;
+}
+
+/** Details for a PSBT-based delegation. */
+export interface BitcoinDelegation {
+  /** Maximum amount authorized in satoshis. */
+  maxSatoshis: number;
+  /** Expiration timestamp for the delegation, ISO 8601. */
+  expiry: string;
+  /** Base64 encoded PSBT template to sign. */
+  psbt: string;
 }
 // --8<-- [end:PaymentCapability]
 

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -29,6 +29,8 @@ export interface AgentCapabilities {
   pushNotifications?: boolean;
   /** Indicates if the agent provides a history of state transitions for a task. */
   stateTransitionHistory?: boolean;
+  /** Configuration for making or delegating payments via supported rails. */
+  payment?: PaymentCapability;
   /** A list of protocol extensions supported by the agent. */
   extensions?: AgentExtension[];
 }
@@ -54,6 +56,31 @@ export interface AgentExtension {
   params?: { [key: string]: any };
 }
 // --8<-- [end:AgentExtension]
+
+// --8<-- [start:PaymentCapability]
+/** Configuration for payment handling supported by the agent. */
+export interface PaymentCapability {
+  /** Bitcoin-specific payment parameters. */
+  bitcoin?: BitcoinCapability;
+}
+
+/** Parameters for Bitcoin payments or PSBT-based delegation. */
+export interface BitcoinCapability {
+  /** Network the address resides on. Defaults to mainnet. */
+  network?: "mainnet" | "testnet" | "signet";
+  /** Receiving address for direct payments. */
+  payTo: string;
+  /** Optional PSBT delegation information. */
+  delegation?: {
+    /** Maximum amount authorized in satoshis. */
+    maxSatoshis: number;
+    /** Expiration timestamp for the delegation, ISO 8601. */
+    expiry: string;
+    /** Base64 encoded PSBT template to sign. */
+    psbt: string;
+  };
+}
+// --8<-- [end:PaymentCapability]
 
 // --8<-- [start:SecurityScheme]
 /**


### PR DESCRIPTION
## Summary
- extend AgentCapabilities with optional bitcoin payment config
- document bitcoin payments feature in sample agent card
- add new topic page describing bitcoin payments
- regenerate JSON schema

## Testing
- `npm run generate`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6888c6a64658832b97b22e95a618397e